### PR TITLE
FromValue return empty collection for missing key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nereon"
 description = "Riboseinc configuration library for Rust"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["John Hedges <john@drystone.co.uk>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/riboseinc/rust-nereon"

--- a/derive-test/src/lib.rs
+++ b/derive-test/src/lib.rs
@@ -299,4 +299,23 @@ mod tests {
         assert!(parse_noc::<B>("a d {d:42}").is_err());
         assert!(parse_noc::<B>("a d [42]").is_err());
     }
+
+    #[test]
+    fn test_missing_vec() {
+        #[derive(Debug, FromValue, PartialEq)]
+        struct A {
+            vec: Vec<String>,
+        }
+        assert_eq!(parse_noc::<A>(""), Ok(A {vec: Vec::default()}));
+    }
+
+    #[test]
+    fn test_missing_map() {
+        use std::collections::HashMap;
+        #[derive(Debug, FromValue, PartialEq)]
+        struct A {
+            map: HashMap<String, String>,
+        }
+        assert_eq!(parse_noc::<A>(""), Ok(A {map: HashMap::default()}));
+    }
 }

--- a/noc/Cargo.toml
+++ b/noc/Cargo.toml
@@ -3,7 +3,7 @@ name = "noc"
 description = "Nereon NOC syntax checker and playground server"
 authors = ["John Hedges <john@drystone.co.uk>"]
 repository = "https://github.com/riboseinc/rust-nereon"
-version = "0.1.2"
+version = "0.1.3"
 license = "BSD-2-Clause"
 exclude = ["/**/*~", "/**/.dir-locals.el"]
 

--- a/noc/src/lib.rs
+++ b/noc/src/lib.rs
@@ -57,7 +57,7 @@ pub fn main() -> Result<(), String> {
 
     config
         .port
-        .map_or_else(|| parse(), |p| playground(p))
+        .map_or_else(parse, playground)
         .map_err(|e| format!("{:?}", e))
 }
 

--- a/src/noc/value.rs
+++ b/src/noc/value.rs
@@ -513,7 +513,7 @@ where
     T: FromValue,
 {
     fn from_value(value: Value) -> Result<Self, String> {
-        T::from_value(value).map(Some).or_else(|_| Ok(None))
+        Ok(Some(T::from_value(value)?))
     }
     fn from_no_value() -> Result<Self, String> {
         Ok(None)
@@ -537,6 +537,9 @@ where
                 })
             })
     }
+    fn from_no_value() -> Result<Self, String> {
+        Ok(HashMap::default())
+    }
 }
 
 impl<T> FromValue for Vec<T>
@@ -555,6 +558,9 @@ where
                     })
                 })
             })
+    }
+    fn from_no_value() -> Result<Self, String> {
+        Ok(Vec::default())
     }
 }
 


### PR DESCRIPTION
* FromValue::<Vec<_>> and FromValue::<HashMap<_,_> both now create
  default collections when trying to convert missing keys

* Fixes FromValue<Option<_>> to fail on parse error rather than
  returning None

* Bumps nereon to 0.3.3